### PR TITLE
Update lib/apple-dev.rb

### DIFF
--- a/lib/apple-dev.rb
+++ b/lib/apple-dev.rb
@@ -246,6 +246,9 @@ module Apple
 	  
 	  def download_profiles(profiles, dumpDir, profileFileName)
 	    profiles.each do |p|
+	      if p.statusXcode != "Active"
+	        info("Profile '#{p.name}' has status '#{p.statusXcode}'. Download skipped.")
+	      else
 	      filename = "#{dumpDir}/#{p.blob_id}.mobileprovision"
 	      info("Downloading profile #{p.blob_id} '#{p.name}'.")
 	      @agent.get(p.download_url).save(filename)
@@ -259,6 +262,7 @@ module Apple
 	      newfilename = "#{dumpDir}/#{basename}.mobileprovision"
 	      File.rename(filename, "#{newfilename}")
 	      info("Saved profile #{p.uuid} '#{p.name}' in #{newfilename}.")
+	      end
 	    end
 	  end
 


### PR DESCRIPTION
Fixed PKCS7 error when attempting to download provisioning profiles that are expired or invalid.
